### PR TITLE
Use regular function and var to support older browsers

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,6 @@
 'use strict';
-const symbolObservable = require('symbol-observable').default;
+var symbolObservable = require('symbol-observable').default;
 
-module.exports = value => Boolean(value && value[symbolObservable] && value === value[symbolObservable]());
+module.exports = function (value) {
+	return Boolean(value && value[symbolObservable] && value === value[symbolObservable]());
+};


### PR DESCRIPTION
3 lines of code but  yet another fix 😢  Just tried to use it, but CI failed on IE < 11 because of const and arrow function. I assume we can keep it simple for this one, without transpilers and just use the old syntax. 