### PR TITLE
Updated function to be compliant of other environments

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,10 @@
 'use strict';
 const symbolObservable = require('symbol-observable').default;
 
-module.exports = value => Boolean(value && value[symbolObservable] && value === value[symbolObservable]());
+module.exports = function isObservable(value) {
+	return Boolean(
+		value &&
+		value[symbolObservable] &&
+		value === value[symbolObservable]()
+	);
+};

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 const symbolObservable = require('symbol-observable').default;
 
-module.exports = function isObservable(value) {
+module.exports = function (value) {
 	return Boolean(
 		value &&
 		value[symbolObservable] &&


### PR DESCRIPTION
## What's done

Updated the `index.js` file to avoid using arrow functions.

If asked, I can rewrite it in a single line like before.

## Why?

This helps when using the library in non-nodejs environments.

## Maintainer's opinion

I understand this package aims to be targeting NodeJS only, and has opinions about not supporting ES5 as mentioned in #8.

You created the package, and you have every right to stick to your decisions.

Given it is a very popular library, I would kindly request you to consider accepting this PR for the ease of adoption by the wider community who want to use it in the browsers too (including old browsers).

NodeJS users are not affected in any negative way by doing this change. ~In fact, it is now exporting a named function.~

With this PR, we are enabling users targeting other environments to use this library too without requiring any additional configuration tweaks in their bundler (like Webpack).

Thanks for the great work!